### PR TITLE
Adds support for BuyPostageXML endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ doc/
 
 *.komodoproject
 test.rb
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    endicia_label_server (0.2.0)
+    endicia_label_server (0.3.0)
       excon (~> 0.45, >= 0.45.3)
       insensitive_hash (~> 0.3.3)
       ox (~> 2.2, >= 2.2.0)
@@ -58,4 +58,4 @@ DEPENDENCIES
   rspec-xsd
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/lib/endicia_label_server.rb
+++ b/lib/endicia_label_server.rb
@@ -6,7 +6,8 @@ module EndiciaLabelServer
     'postage_rates',
     'user_sign_up',
     'postage_label',
-    'change_pass_phrase'
+    'change_pass_phrase',
+    'buy_postage'
   ]
 
   autoload :SERVICES,              "#{GEM_NAME}/services"

--- a/lib/endicia_label_server/builders/buy_postage_builder.rb
+++ b/lib/endicia_label_server/builders/buy_postage_builder.rb
@@ -1,0 +1,17 @@
+require 'ox'
+
+module EndiciaLabelServer
+  module Builders
+    class BuyPostageBuilder < BuilderBase
+      include Ox
+
+      def initialize(opts = {})
+        super 'RecreditRequest', opts
+      end
+
+      def post_field
+        'BuyPostageRequestXML'
+      end
+    end
+  end
+end

--- a/lib/endicia_label_server/builders/buy_postage_builder.rb
+++ b/lib/endicia_label_server/builders/buy_postage_builder.rb
@@ -10,7 +10,7 @@ module EndiciaLabelServer
       end
 
       def post_field
-        'BuyPostageRequestXML'
+        'recreditRequestXML'
       end
     end
   end

--- a/lib/endicia_label_server/connection.rb
+++ b/lib/endicia_label_server/connection.rb
@@ -17,8 +17,8 @@ module EndiciaLabelServer
 
     attr_accessor :url
 
-    TEST_URL = 'https://LabelServer.Endicia.com'
-    LIVE_URL = 'https://LabelServer.Endicia.com'
+    TEST_URL = 'https://elstestserver.endicia.com'
+    LIVE_URL = 'https://labelserver.endicia.com'
     ROOT_PATH = '/LabelService/EwsLabelService.asmx/'
 
     GET_POSTAGE_LABEL_ENDPOINT = 'GetPostageLabelXML'
@@ -26,6 +26,7 @@ module EndiciaLabelServer
     REQUEST_RATES_ENDPOINT = 'CalculatePostageRatesXML'
     GET_USER_SIGNUP_ENDPOINT = 'GetUserSignUpXML'
     CHANGE_PASS_PHRASE_ENDPOINT = 'ChangePassPhraseXML'
+    BUY_POSTAGE_ENDPOINT = 'BuyPostageXML'
 
     DEFAULT_PARAMS = {
       test_mode: false
@@ -68,6 +69,11 @@ module EndiciaLabelServer
     def change_pass_phrase(builder = nil, &block)
       builder_proxy(builder, CHANGE_PASS_PHRASE_ENDPOINT,
                     ChangePassPhraseBuilder, ChangePassPhraseParser, block)
+    end
+
+    def buy_postage(builder = nil, &block)
+      builder_proxy(builder, BUY_POSTAGE_ENDPOINT,
+                    BuyPostageBuilder, BuyPostageParser, block)
     end
 
     private

--- a/lib/endicia_label_server/parsers/buy_postage_parser.rb
+++ b/lib/endicia_label_server/parsers/buy_postage_parser.rb
@@ -1,0 +1,24 @@
+module EndiciaLabelServer
+  module Parsers
+    class BuyPostageParser < ParserBase
+      attr_accessor :postage_balance, :ascending_balance, :account_status, :transaction_id
+
+      def value(value)
+        super
+
+        string_value = value.as_s
+        if switch_active? :CertifiedIntermediary
+          if switch_active? :PostageBalance
+            self.postage_balance = string_value
+          elsif switch_active? :AscendingBalance
+            self.ascending_balance = string_value
+          elsif switch_active? :AccountStatus
+            self.account_status = string_value
+          end
+        elsif switch_active? :TransactionID
+          self.transaction_id = string_value
+        end
+      end
+    end
+  end
+end

--- a/lib/endicia_label_server/version.rb
+++ b/lib/endicia_label_server/version.rb
@@ -1,7 +1,7 @@
 module EndiciaLabelServer
   module Version
     MAJOR = 0
-    MINOR = 2
+    MINOR = 3
     PATCH = 0
     BUILD = nil
 

--- a/spec/endicia_label_server/connection/buy_postage_spec.rb
+++ b/spec/endicia_label_server/connection/buy_postage_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'tempfile'
+require 'faker'
+
+describe EndiciaLabelServer::Connection, '.buy_postage' do
+  before do
+    Excon.defaults[:mock] = true
+  end
+
+  after do
+    Excon.stubs.clear
+  end
+
+  let(:stub_path) { File.expand_path("../../../stubs", __FILE__) }
+  let(:server) { EndiciaLabelServer::Connection.new(test_mode: true) }
+
+  context "when buying postage" do
+    before do
+      Excon.stub({:method => :post}) do |params|
+        case params[:path]
+          when "#{EndiciaLabelServer::Connection::ROOT_PATH}#{EndiciaLabelServer::Connection::BUY_POSTAGE_ENDPOINT}"
+            {body: File.read("#{stub_path}/buy_postage_success.xml"), status: 200}
+        end
+      end
+    end
+
+    subject do
+      server.buy_postage do |connection|
+        connection.add :requester_id, ENV['ENDICIA_REQUESTER_ID']
+        connection.add :request_id, 'ABC'
+        connection.add :certified_intermediary, {
+            account_id: '1234567',
+            pass_phrase: 'SUPER SECRET AND SECURE PASSWORD',
+            token: 'AGAIN ANOTHER AWESOME SECRET TOKEN'
+        }
+        connection.add recredit_amount: '5.00'
+      end
+    end
+
+    it "should return postage balance" do
+      expect { subject }.not_to raise_error
+      expect(subject.postage_balance).to eql "5.00"
+    end
+
+    it "should return ascending balance" do
+      expect { subject }.not_to raise_error
+      expect(subject.ascending_balance).to eql "5.00"
+    end
+
+    it "should return account status" do
+      expect { subject }.not_to raise_error
+      expect(subject.account_status).to eql "A"
+    end
+
+    it "should return transaction id" do
+      expect { subject }.not_to raise_error
+      expect(subject.transaction_id).to eql "1.00"
+    end
+  end
+end

--- a/spec/stubs/buy_postage_success.xml
+++ b/spec/stubs/buy_postage_success.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RecreditRequestResponse>
+  <Status>0</Status>
+  <ErrorMessage></ErrorMessage>
+  <RequesterID>123</RequesterID>
+  <RequestID>123</RequestID>
+  <CertifiedIntermediary>
+    <AccountID>1000000</AccountID>
+    <SerialNumber>1</SerialNumber>
+    <PostageBalance>5.00</PostageBalance>
+    <AscendingBalance>5.00</AscendingBalance>
+    <AccountStatus>A</AccountStatus>
+    <DeviceID>123456789012</DeviceID>
+    <ReferenceID>asdf</ReferenceID>
+  </CertifiedIntermediary>
+  <TransactionID>1.00</TransactionID>
+  <ControlRegister>1.00</ControlRegister>
+</RecreditRequestResponse>


### PR DESCRIPTION
- Add `buy_postage` method. Similar to other Connection class methods.
- Adds buy_postage builder and parser.
- Updates TEST_URL and LIVE_URL. TEST_URL was pointing to live server.
- Bumps version to 0.3.0
- Tests pass, and coverage is still 100%

Adding the BuyPostage functionality makes it possible to use the gem to complete a new Endicia account setup. They require you to complete 3 steps - change the passphrase, buy postage, create a label.